### PR TITLE
feat: add API for report categories and use in report form

### DIFF
--- a/app/(unauthenticated)/(pages)/report/page.tsx
+++ b/app/(unauthenticated)/(pages)/report/page.tsx
@@ -2,17 +2,30 @@
 
 import ReportForm from "@/components/report/report-form"
 import ReceiptModal from "@/components/report/receipt-modal"
-import { useState } from "react"
-
-// TODO: Replace with real categories from DB when API is ready
-const demoCategories = [
-  { id: "safety", name: "Safety" },
-  { id: "fraud", name: "Fraud" },
-  { id: "harassment", name: "Harassment" },
-]
+import { useState, useEffect } from "react"
 
 export default function ReportPage() {
   const [receipt, setReceipt] = useState<{ code: string; passphrase: string; feedbackDueAt?: string | null } | null>(null)
+  const [categories, setCategories] = useState<{ id: string; name: string }[]>([])
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const params = new URLSearchParams(window.location.search)
+        const channel = params.get("channel")
+        const org = params.get("org")
+        const query = channel ? `?channel=${encodeURIComponent(channel)}` : org ? `?org=${encodeURIComponent(org)}` : ""
+        const resp = await fetch(`/api/report-categories${query}`)
+        if (resp.ok) {
+          const data = await resp.json()
+          setCategories(data)
+        }
+      } catch (e) {
+        console.error("Failed to load categories", e)
+      }
+    }
+    load()
+  }, [])
 
   async function handleSubmit(formData: any) {
     const resp = await fetch("/api/reports", {
@@ -34,7 +47,7 @@ export default function ReportPage() {
     <div className="container mx-auto max-w-3xl py-10">
       <h1 className="text-2xl font-semibold mb-6">Submit a Report</h1>
       <ReportForm
-        categories={demoCategories}
+        categories={categories}
         captchaSiteKey={siteKey}
         onSubmit={handleSubmit}
       />

--- a/app/api/report-categories/route.ts
+++ b/app/api/report-categories/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/db"
+import { reportCategories } from "@/db/schema/reportCategories"
+import { reportingChannels } from "@/db/schema/reportingChannels"
+import { auth } from "@clerk/nextjs/server"
+import { eq, and } from "drizzle-orm"
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url)
+    const channelSlug = req.headers.get("x-channel-slug") || url.searchParams.get("channel") || undefined
+    let orgId: string | null = null
+
+    if (channelSlug) {
+      const channel = await db.query.reportingChannels.findFirst({ where: eq(reportingChannels.slug, channelSlug) })
+      if (!channel) {
+        return NextResponse.json({ error: "Channel not found" }, { status: 404 })
+      }
+      orgId = channel.orgId
+    } else {
+      const orgParam = url.searchParams.get("org")
+      if (orgParam) {
+        orgId = orgParam
+      } else {
+        const { orgId: clerkOrgId } = await auth()
+        if (clerkOrgId) {
+          const { getDbOrgIdForClerkOrg } = await import("@/src/server/orgs")
+          orgId = await getDbOrgIdForClerkOrg(clerkOrgId)
+        }
+      }
+    }
+
+    if (!orgId) {
+      return NextResponse.json({ error: "Organization context required" }, { status: 400 })
+    }
+
+    const rows = await db
+      .select({ id: reportCategories.id, name: reportCategories.name })
+      .from(reportCategories)
+      .where(and(eq(reportCategories.orgId, orgId), eq(reportCategories.active, true)))
+      .orderBy(reportCategories.name)
+
+    return NextResponse.json(rows, { status: 200 })
+  } catch (err) {
+    console.error("[report-categories] GET failed", err)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/report-categories` endpoint for fetching organization categories
- load categories on the unauthenticated report page and pass to `ReportForm`

## Testing
- `npm test` (fails: DATABASE_URL is not set)
- `npm run lint` (fails: many lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68ae3b94fccc83219d75d852f50f6808