### PR TITLE
feat: add security headers

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,23 @@
+# Security Headers
+
+The application sets a standard set of HTTP security headers in `middleware.ts`:
+
+- **Content-Security-Policy** restricts resource loading to trusted origins. Allowed services:
+  - Clerk domains (`*.clerk.com`, `*.clerk.dev`, `*.clerk.services`)
+  - Supabase instances (`*.supabase.co`)
+  - Stripe (`js.stripe.com`, `api.stripe.com`, `hooks.stripe.com`)
+
+  ```
+  default-src 'self';
+  script-src 'self' 'unsafe-inline' https://js.stripe.com;
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data:;
+  connect-src 'self' https://*.clerk.com https://*.clerk.dev https://*.clerk.services https://*.supabase.co https://api.stripe.com;
+  frame-src 'self' https://js.stripe.com https://hooks.stripe.com;
+  ```
+- **Strict-Transport-Security**: `max-age=63072000; includeSubDomains; preload`
+- **X-Frame-Options**: `DENY`
+- **Referrer-Policy**: `no-referrer`
+- **X-Content-Type-Options**: `nosniff`
+
+Together these headers harden the app against clickjacking, content injection and other web threats.

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,24 @@ export default clerkMiddleware(async (auth, req) => {
     return redirectToSignIn()
   }
 
-  return NextResponse.next()
+  const csp = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' https://js.stripe.com",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "connect-src 'self' https://*.clerk.com https://*.clerk.dev https://*.clerk.services https://*.supabase.co https://api.stripe.com",
+    "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
+  ].join('; ')
+
+  const headers = new Headers({
+    "Content-Security-Policy": csp,
+    "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+  })
+
+  return NextResponse.next({ headers })
 })
 
 export const config = {


### PR DESCRIPTION
## Summary
- add CSP, HSTS, X-Frame-Options, Referrer-Policy and other security headers
- document header policy

## Testing
- `npm run lint` *(fails: Unexpected any and other existing lint errors)*
- `npm test` *(fails: DATABASE_URL is not set and Clerk mock errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3c0bbfc48321a5dbd2a3a31d8d7f