### PR TITLE
Add rate limiter tests

### DIFF
--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { InMemoryRateLimiter, buildRateLimitHeaders, getClientIp, rateLimit } from './rate-limit'
+
+function createReq(headers: Record<string, string> = {}, ip?: string) {
+  return { headers: new Headers(headers), ip } as any
+}
+
+describe('InMemoryRateLimiter', () => {
+  let limiter: InMemoryRateLimiter
+  beforeEach(() => {
+    limiter = new InMemoryRateLimiter()
+  })
+
+  it('blocks after reaching the limit', () => {
+    const key = 'user1'
+    const limit = 2
+    const windowMs = 1000
+    const first = limiter.consume(key, limit, windowMs)
+    const second = limiter.consume(key, limit, windowMs)
+    const third = limiter.consume(key, limit, windowMs)
+
+    expect(first.allowed).toBe(true)
+    expect(second.allowed).toBe(true)
+    expect(third.allowed).toBe(false)
+    expect(third.retryAfter).toBeGreaterThanOrEqual(0)
+  })
+})
+
+describe('buildRateLimitHeaders', () => {
+  it('includes rate limit information and retry header', () => {
+    const result = { allowed: false, remaining: 0, limit: 5, reset: Date.now() + 1000, retryAfter: 10 }
+    const headers = buildRateLimitHeaders(result)
+    expect(headers['X-RateLimit-Limit']).toBe('5')
+    expect(headers['X-RateLimit-Remaining']).toBe('0')
+    expect(headers['X-RateLimit-Reset']).toBe(String(Math.ceil(result.reset / 1000)))
+    expect(headers['Retry-After']).toBe('10')
+  })
+})
+
+describe('getClientIp', () => {
+  it('prefers x-forwarded-for header', () => {
+    const req = createReq({ 'x-forwarded-for': '1.2.3.4' })
+    expect(getClientIp(req)).toBe('1.2.3.4')
+  })
+
+  it('falls back to x-real-ip header', () => {
+    const req = createReq({ 'x-real-ip': '5.6.7.8' })
+    expect(getClientIp(req)).toBe('5.6.7.8')
+  })
+
+  it('falls back to request.ip when headers are missing', () => {
+    const req = createReq({}, '9.9.9.9')
+    expect(getClientIp(req)).toBe('9.9.9.9')
+  })
+})
+
+describe('rateLimit helper', () => {
+  it('uses provided limiter and options', () => {
+    const limiter = new InMemoryRateLimiter()
+    const res1 = rateLimit({ key: 'abc', limit: 1, windowMs: 1000, limiter })
+    const res2 = rateLimit({ key: 'abc', limit: 1, windowMs: 1000, limiter })
+    expect(res1.allowed).toBe(true)
+    expect(res2.allowed).toBe(false)
+  })
+})
+

--- a/tests/e2e/rate-limit.spec.ts
+++ b/tests/e2e/rate-limit.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test'
+
+test('rate limit endpoint enforces request limit', async ({ request }) => {
+  for (let i = 0; i < 5; i++) {
+    const res = await request.get('/api/rate-limit-test')
+    expect(res.status(), `request ${i + 1} should succeed`).toBe(200)
+  }
+  const blocked = await request.get('/api/rate-limit-test')
+  expect(blocked.status()).toBe(429)
+  const remaining = blocked.headers()['x-ratelimit-remaining']
+  expect(remaining).toBe('0')
+})
+


### PR DESCRIPTION
## Summary
- add unit tests for InMemoryRateLimiter and related helpers
- add Playwright e2e test verifying rate limit endpoint

## Testing
- `npx vitest run lib/rate-limit.test.ts`
- `npm run test:unit` *(fails: DATABASE_URL is not set)*
- `npm run test:e2e` *(fails: Process from config.webServer exited early: DATABASE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3de0798083218e913dca2d240a29