### PR TITLE
Refactor case detail UI with Tweakcn components

### DIFF
--- a/app/(authenticated)/dashboard/cases/[id]/case-tabs.tsx
+++ b/app/(authenticated)/dashboard/cases/[id]/case-tabs.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useState } from "react"
 import dynamic from "next/dynamic"
 import { CaseLogs } from "./case-logs"
 import { ReportLog } from "@/db/schema/reportLogs"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { Card, CardContent } from "@/components/ui/card"
 
 type ThreadItem = {
   id: string
@@ -28,40 +29,29 @@ export default function CaseTabs({
   initialThread: ThreadItem[]
   initialLogs: ReportLog[]
 }) {
-  const [tab, setTab] = useState<"messages" | "logs" | "internal">("messages")
   return (
-    <div className="rounded border">
-      <div className="flex items-center gap-4 border-b px-4 pt-2">
-        <button
-          className={`px-3 py-2 text-sm font-medium ${tab === "messages" ? "border-primary border-b-2" : "text-muted-foreground"}`}
-          onClick={() => setTab("messages")}
-        >
-          Messages
-        </button>
-        <button
-          className={`px-3 py-2 text-sm ${tab === "logs" ? "border-primary border-b-2 font-medium" : "text-muted-foreground"}`}
-          onClick={() => setTab("logs")}
-        >
-          Logs
-        </button>
-        <button
-          className={`px-3 py-2 text-sm ${tab === "internal" ? "border-primary border-b-2 font-medium" : "text-muted-foreground"}`}
-          onClick={() => setTab("internal")}
-        >
-          Internal notes
-        </button>
-      </div>
-      <div className="p-4">
-        {tab === "messages" && (
-          <CaseThreadClient reportId={reportId} initialThread={initialThread} />
-        )}
-        {tab === "logs" && <CaseLogs logs={initialLogs} />}
-        {tab === "internal" && (
-          <div className="text-muted-foreground text-sm">
-            Internal notes coming soon.
-          </div>
-        )}
-      </div>
-    </div>
+    <Card>
+      <Tabs defaultValue="messages">
+        <TabsList className="grid w-full grid-cols-3 border-b bg-transparent">
+          <TabsTrigger value="messages">Messages</TabsTrigger>
+          <TabsTrigger value="logs">Logs</TabsTrigger>
+          <TabsTrigger value="internal">Internal notes</TabsTrigger>
+        </TabsList>
+        <CardContent className="p-4">
+          <TabsContent value="messages">
+            <CaseThreadClient reportId={reportId} initialThread={initialThread} />
+          </TabsContent>
+          <TabsContent value="logs">
+            <CaseLogs logs={initialLogs} />
+          </TabsContent>
+          <TabsContent value="internal">
+            <div className="text-sm text-muted-foreground">
+              Internal notes coming soon.
+            </div>
+          </TabsContent>
+        </CardContent>
+      </Tabs>
+    </Card>
   )
 }
+

--- a/app/(authenticated)/dashboard/cases/[id]/page.tsx
+++ b/app/(authenticated)/dashboard/cases/[id]/page.tsx
@@ -9,6 +9,12 @@ import { auth } from "@clerk/nextjs/server"
 import { organizations } from "@/db/schema/organizations"
 import InfoPanel from "./info-panel"
 import { OptionsPanel } from "./options-panel"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
 
 export default async function CaseViewPage({
   params
@@ -74,29 +80,25 @@ export default async function CaseViewPage({
       <OptionsPanel />
       <div className="grid gap-6 lg:grid-cols-3">
         <div className="space-y-4 lg:col-span-2">
-          <div className="rounded border p-4">
-            <div className="mb-2 text-base font-semibold">Case detail</div>
-            <div className="grid gap-3 text-sm">
+          <Card>
+            <CardHeader className="p-4">
+              <CardTitle className="text-base">Case detail</CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-3 p-4 pt-0 text-sm">
               <div>
-                <div className="text-muted-foreground text-xs uppercase">
-                  Sender
-                </div>
+                <div className="text-xs uppercase text-muted-foreground">Sender</div>
                 <div>{senderLabel}</div>
               </div>
               <div>
-                <div className="text-muted-foreground text-xs uppercase">
-                  Category
-                </div>
+                <div className="text-xs uppercase text-muted-foreground">Category</div>
                 <div>{cat?.name || "—"}</div>
               </div>
               <div>
-                <div className="text-muted-foreground text-xs uppercase">
-                  Case ID
-                </div>
+                <div className="text-xs uppercase text-muted-foreground">Case ID</div>
                 <div className="font-mono">{report.caseId}</div>
               </div>
-            </div>
-          </div>
+            </CardContent>
+          </Card>
 
           <CaseTabs reportId={String(report.id)} initialThread={items} initialLogs={logs} />
         </div>


### PR DESCRIPTION
## Summary
- replace manual case detail markup with Tweakcn Card
- reimplement case thread tabs using Tweakcn Tabs and Card

## Testing
- `npm test` (fails: DATABASE_URL is not set)
- `npm run lint` (fails: numerous no-explicit-any errors)

------
https://chatgpt.com/codex/tasks/task_e_68af63d812048321b7bbe5fd26ca7126