### PR TITLE
Refactor department page to Tweakcn components

### DIFF
--- a/app/(authenticated)/dashboard/departments/page.tsx
+++ b/app/(authenticated)/dashboard/departments/page.tsx
@@ -1,9 +1,20 @@
 import { RequireRole } from "@/components/auth/require-role"
 import { db } from "@/db"
 import { ROLES } from "@/lib/authz"
-import { departments } from "@/db/schema/departments"
+import { departments, type SelectDepartment } from "@/db/schema/departments"
 import { eq } from "drizzle-orm"
 import { auth } from "@clerk/nextjs/server"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table"
 
 export default async function DepartmentsPage() {
   const { orgId: clerkOrgId } = await auth()
@@ -22,33 +33,27 @@ export default async function DepartmentsPage() {
           </p>
         </div>
         <form action="/api/departments" method="post" className="flex gap-2">
-          <input
-            name="name"
-            className="rounded border px-3 py-2 text-sm"
-            placeholder="New department name"
-          />
-          <button className="bg-primary text-primary-foreground rounded px-3 py-2 text-sm">
-            Add
-          </button>
+          <Input name="name" placeholder="New department name" />
+          <Button type="submit">Add</Button>
         </form>
-        <div className="overflow-hidden rounded border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted">
-              <tr>
-                <th className="p-2 text-left">Name</th>
-                <th className="p-2 text-left">Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              {departs.map((r: any) => (
-                <tr key={r.id} className="border-t">
-                  <td className="p-2">{r.name}</td>
-                  <td className="p-2">{r.description || "—"}</td>
-                </tr>
+        <Card>
+          <Table>
+            <TableHeader className="bg-muted">
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Description</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {departs.map((r: SelectDepartment) => (
+                <TableRow key={r.id}>
+                  <TableCell>{r.name}</TableCell>
+                  <TableCell>{r.description || "—"}</TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
-        </div>
+            </TableBody>
+          </Table>
+        </Card>
       </div>
     </RequireRole>
   )


### PR DESCRIPTION
## Summary
- replace department form elements with Tweakcn `Input` and `Button`
- display department list inside a `Card` using Tweakcn `Table`
- type department rows with `SelectDepartment`

## Testing
- `npm test` *(fails: DATABASE_URL is not set)*
- `npm run lint` *(fails: Unexpected any in multiple files)*


------
https://chatgpt.com/codex/tasks/task_e_68af68fc13608321b93add75d8965ae4