### PR TITLE
refactor: use design system Button

### DIFF
--- a/app/(authenticated)/dashboard/(pages)/account/tabs.tsx
+++ b/app/(authenticated)/dashboard/(pages)/account/tabs.tsx
@@ -4,15 +4,16 @@ import { useState } from "react"
 import { GeneralTab } from "./tabs/general"
 import { SecurityTab } from "./tabs/security"
 import { NotificationsTab } from "./tabs/notifications"
+import { Button } from "tweakcn/ui/button"
 
 export default function AccountTabs() {
   const [tab, setTab] = useState<"general" | "security" | "notifications">("general")
   return (
     <div className="rounded border">
       <div className="flex items-center gap-4 border-b px-4 pt-2">
-        <button className={`px-3 py-2 text-sm ${tab === "general" ? "border-primary border-b-2 font-medium" : "text-muted-foreground"}`} onClick={() => setTab("general")}>General</button>
-        <button className={`px-3 py-2 text-sm ${tab === "security" ? "border-primary border-b-2 font-medium" : "text-muted-foreground"}`} onClick={() => setTab("security")}>Security</button>
-        <button className={`px-3 py-2 text-sm ${tab === "notifications" ? "border-primary border-b-2 font-medium" : "text-muted-foreground"}`} onClick={() => setTab("notifications")}>Notifications</button>
+        <Button className={`px-3 py-2 text-sm ${tab === "general" ? "border-b-2 border-primary font-medium" : "text-muted-foreground"}`} onClick={() => setTab("general")} variant="link" size="sm">General</Button>
+        <Button className={`px-3 py-2 text-sm ${tab === "security" ? "border-b-2 border-primary font-medium" : "text-muted-foreground"}`} onClick={() => setTab("security")} variant="link" size="sm">Security</Button>
+        <Button className={`px-3 py-2 text-sm ${tab === "notifications" ? "border-b-2 border-primary font-medium" : "text-muted-foreground"}`} onClick={() => setTab("notifications")} variant="link" size="sm">Notifications</Button>
       </div>
       <div className="p-4">
         {tab === "general" && <GeneralTab />}

--- a/app/(authenticated)/dashboard/(pages)/account/tabs/general.tsx
+++ b/app/(authenticated)/dashboard/(pages)/account/tabs/general.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import { useEffect, useMemo, useState } from "react"
 import { useAuth, useOrganization, useUser } from "@clerk/nextjs"
+import { Button } from "tweakcn/ui/button"
 
 type Role = "ADMIN" | "HANDLER" | "AUDITOR"
 
@@ -85,9 +86,9 @@ export function GeneralTab() {
                 <div className="h-16 w-16" />
               )}
             </div>
-            <button className="rounded border px-3 py-1 text-sm" disabled>
+            <Button className="px-3 py-1 text-sm" disabled variant="outline" size="sm">
               Change
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -135,13 +136,15 @@ export function GeneralTab() {
           </select>
         </div>
         <div>
-          <button
-            className="bg-primary text-primary-foreground rounded px-3 py-2 text-sm disabled:opacity-50"
+          <Button
+            className="px-3 py-2 text-sm"
             onClick={onSave}
             disabled={saving}
+            variant="primary"
+            size="sm"
           >
             Save changes
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/app/(authenticated)/dashboard/(pages)/account/tabs/notifications.tsx
+++ b/app/(authenticated)/dashboard/(pages)/account/tabs/notifications.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { Button } from "tweakcn/ui/button"
 
 type Prefs = {
   emailCaseUpdates: boolean
@@ -55,7 +56,9 @@ export function NotificationsTab() {
         </label>
       </div>
       <div>
-        <button className="rounded bg-primary px-3 py-2 text-sm text-primary-foreground disabled:opacity-50" onClick={onSave} disabled={saving}>Save preferences</button>
+        <Button className="px-3 py-2 text-sm" onClick={onSave} disabled={saving} variant="primary" size="sm">
+          Save preferences
+        </Button>
       </div>
     </div>
   )

--- a/app/(authenticated)/dashboard/(pages)/billing/components/PlanSelector.tsx
+++ b/app/(authenticated)/dashboard/(pages)/billing/components/PlanSelector.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Button } from "tweakcn/ui/button"
 
 type Plan = "free" | "pro" | "enterprise"
 
@@ -78,9 +79,13 @@ export default function PlanSelector({ currentPlan }: { currentPlan: Plan }) {
                 </ul>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <button className={`w-full rounded ${highlight ? "bg-primary text-primary-foreground" : "border"} px-3 py-2 text-sm`}>
+                    <Button
+                      className={`w-full ${highlight ? "bg-primary text-primary-foreground" : ""} px-3 py-2 text-sm`}
+                      variant={highlight ? "primary" : "outline"}
+                      size="sm"
+                    >
                       {p.cta}
-                    </button>
+                    </Button>
                   </TooltipTrigger>
                   <TooltipContent>{p.key === "enterprise" ? "Contact us for a tailored plan" : "Proceed to checkout"}</TooltipContent>
                 </Tooltip>

--- a/app/(authenticated)/dashboard/_components/onboarding-actions.tsx
+++ b/app/(authenticated)/dashboard/_components/onboarding-actions.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Button } from "@/components/ui/button"
+import { Button } from "tweakcn/ui/button"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 import { X } from "lucide-react"
@@ -67,14 +67,16 @@ export function OnboardingActions({
             <div className="fixed inset-0 z-50 flex items-center justify-center">
               <div className="absolute inset-0 bg-black/60" onClick={() => setShowIntro(false)} />
               <div className="relative z-10 w-[90vw] max-w-3xl rounded-md bg-card p-4 shadow-xl">
-                <button
+                <Button
                   type="button"
                   className="absolute right-3 top-3 text-muted-foreground hover:text-foreground"
                   aria-label="Close"
                   onClick={() => setShowIntro(false)}
+                  variant="ghost"
+                  size="icon"
                 >
                   <X className="h-5 w-5" />
-                </button>
+                </Button>
                 <div className="space-y-3">
                   <div className="text-lg font-semibold">Welcome tour</div>
                   <div className="aspect-video w-full overflow-hidden rounded">

--- a/app/(authenticated)/dashboard/cases/[id]/info-panel.tsx
+++ b/app/(authenticated)/dashboard/cases/[id]/info-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState, useTransition } from "react"
 import type { SelectReport } from "@/db/schema/reports"
 import { Avatar } from "@/components/ui/avatar"
 import { AvatarFallback } from "@radix-ui/react-avatar"
+import { Button } from "tweakcn/ui/button"
 
 type ReportStatus =
   | "IN_PROGRESS"
@@ -201,13 +202,15 @@ export default function InfoPanel({
                       ))}
                     </div>
                   </div>
-                  <button
-                    className="inline-flex h-6 w-6 items-center justify-center rounded border text-xs"
+                  <Button
+                    className="h-6 w-6 text-xs"
                     title="Assign member"
                     onClick={() => setShowPicker(true)}
+                    variant="outline"
+                    size="icon"
                   >
                     +
-                  </button>
+                  </Button>
                 </div>
               ) : (
                 <div>{i.value}</div>
@@ -225,12 +228,14 @@ export default function InfoPanel({
           <div className="w-full max-w-md rounded bg-white p-4 shadow-lg">
             <div className="mb-2 flex items-center justify-between">
               <div className="text-base font-semibold">Assign member</div>
-              <button
-                className="text-muted-foreground text-sm"
+              <Button
+                className="text-sm text-muted-foreground"
                 onClick={() => setShowPicker(false)}
+                variant="link"
+                size="sm"
               >
                 Close
-              </button>
+              </Button>
             </div>
             <input
               className="mb-3 w-full rounded border px-2 py-1 text-sm"
@@ -240,10 +245,12 @@ export default function InfoPanel({
             />
             <div className="max-h-64 overflow-auto">
               {filtered.map(m => (
-                <button
+                <Button
                   key={m.orgMemberId}
-                  className="hover:bg-muted/50 flex w-full items-center justify-between rounded px-2 py-2 text-left"
+                  className="flex w-full items-center justify-between px-2 py-2 text-left hover:bg-muted/50"
                   onClick={() => assign(m.orgMemberId)}
+                  variant="ghost"
+                  size="sm"
                 >
                   <div>
                     <div className="text-sm font-medium">
@@ -254,7 +261,7 @@ export default function InfoPanel({
                     </div>
                   </div>
                   <div className="text-xs">Assign</div>
-                </button>
+                </Button>
               ))}
               {filtered.length === 0 && (
                 <div className="text-muted-foreground py-6 text-center text-sm">

--- a/app/(authenticated)/dashboard/cases/[id]/options-panel.tsx
+++ b/app/(authenticated)/dashboard/cases/[id]/options-panel.tsx
@@ -1,19 +1,23 @@
 "use client"
 
+import { Button } from "tweakcn/ui/button"
+
 export const OptionsPanel = () => {
   return (
     <div className="mb-6 flex justify-end">
       <div className="flex gap-2">
-        <button
+        <Button
           type="button"
-          className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+          className="px-3 py-2 text-sm"
+          variant="outline"
+          size="sm"
           onClick={() => {
             // Placeholder for export logic
             alert("Export functionality coming soon.")
           }}
         >
           <svg
-            className="w-4 h-4 mr-2"
+            className="mr-2 h-4 w-4"
             fill="none"
             stroke="currentColor"
             strokeWidth={2}
@@ -23,17 +27,19 @@ export const OptionsPanel = () => {
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v12m0 0l-4-4m4 4l4-4M4 20h16" />
           </svg>
           Export
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
-          className="inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 transition hover:bg-gray-50"
+          className="px-3 py-2 text-sm"
+          variant="destructive"
+          size="sm"
           onClick={() => {
             // Placeholder for archive logic
             alert("Archive functionality coming soon.")
           }}
         >
           <svg
-            className="w-4 h-4 mr-2"
+            className="mr-2 h-4 w-4"
             fill="none"
             stroke="currentColor"
             strokeWidth={2}
@@ -44,17 +50,19 @@ export const OptionsPanel = () => {
             <path strokeLinecap="round" strokeLinejoin="round" d="M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8" />
           </svg>
           Archive
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
-          className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+          className="px-3 py-2 text-sm"
+          variant="outline"
+          size="sm"
           onClick={() => {
             // Placeholder for redaction mode logic
             alert("Redaction Mode toggled (functionality coming soon).")
           }}
         >
           <svg
-            className="w-4 h-4 mr-2"
+            className="mr-2 h-4 w-4"
             fill="none"
             stroke="currentColor"
             strokeWidth={2}
@@ -65,7 +73,7 @@ export const OptionsPanel = () => {
             <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h8" />
           </svg>
           Redaction Mode
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/app/(authenticated)/dashboard/categories/page.tsx
+++ b/app/(authenticated)/dashboard/categories/page.tsx
@@ -4,6 +4,7 @@ import { reportCategories } from "@/db/schema/reportCategories"
 import { eq } from "drizzle-orm"
 import { addCategory, setCategoryActive } from "@/actions/categories"
 import Link from "next/link"
+import { Button } from "tweakcn/ui/button"
 
 export default async function CategoriesPage() {
 	const { orgId: clerkOrgId } = await auth()
@@ -28,7 +29,9 @@ export default async function CategoriesPage() {
 							</div>
                     <div className="flex justify-end gap-2">
                         <Link href="/dashboard/categories" className="rounded border px-3 py-1 text-sm">Cancel</Link>
-                        <button type="submit" className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground">Save</button>
+                        <Button type="submit" className="px-3 py-1 text-sm" variant="primary" size="sm">
+                            Save
+                        </Button>
                     </div>
 						</form>
 					</div>
@@ -51,7 +54,7 @@ export default async function CategoriesPage() {
 								<td className="p-2">{c.active ? "Active" : "Inactive"}</td>
 								<td className="p-2">
 									<form action={async (formData) => { 'use server'; await setCategoryActive(c.id, !c.active) }}>
-										<button type="submit" className="rounded border px-2 py-1 text-xs">{c.active ? "Deactivate" : "Activate"}</button>
+                                                                                <Button type="submit" className="px-2 py-1 text-xs" variant="outline" size="sm">{c.active ? "Deactivate" : "Activate"}</Button>
 									</form>
 								</td>
 							</tr>

--- a/app/(authenticated)/dashboard/departments/page.tsx
+++ b/app/(authenticated)/dashboard/departments/page.tsx
@@ -4,6 +4,7 @@ import { ROLES } from "@/lib/authz"
 import { departments } from "@/db/schema/departments"
 import { eq } from "drizzle-orm"
 import { auth } from "@clerk/nextjs/server"
+import { Button } from "tweakcn/ui/button"
 
 export default async function DepartmentsPage() {
   const { orgId: clerkOrgId } = await auth()
@@ -27,9 +28,9 @@ export default async function DepartmentsPage() {
             className="rounded border px-3 py-2 text-sm"
             placeholder="New department name"
           />
-          <button className="bg-primary text-primary-foreground rounded px-3 py-2 text-sm">
+          <Button className="px-3 py-2 text-sm" variant="primary" size="sm">
             Add
-          </button>
+          </Button>
         </form>
         <div className="overflow-hidden rounded border">
           <table className="w-full text-sm">

--- a/app/(authenticated)/dashboard/register/page.tsx
+++ b/app/(authenticated)/dashboard/register/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@clerk/nextjs/server"
 import { listRegister } from "@/src/server/services/register"
+import { Button } from "tweakcn/ui/button"
 
 export default async function RegisterPage({ searchParams }: { searchParams: { status?: string; categoryId?: string; q?: string } }) {
   const { orgId: clerkOrgId } = await auth()
@@ -20,8 +21,8 @@ export default async function RegisterPage({ searchParams }: { searchParams: { s
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <input className="border rounded px-3 py-2 text-sm" placeholder="Search case id..." defaultValue={searchParams?.q || ""} name="q" />
-          <button className="text-sm underline">Filters</button>
-          <button className="text-sm underline">Advanced search</button>
+          <Button className="underline" variant="link" size="sm">Filters</Button>
+          <Button className="underline" variant="link" size="sm">Advanced search</Button>
         </div>
         <div className="flex items-center gap-2">
           <select className="border rounded px-3 py-2 text-sm" defaultValue={searchParams?.status || "all"}>
@@ -38,7 +39,9 @@ export default async function RegisterPage({ searchParams }: { searchParams: { s
       <div className="overflow-x-auto border rounded-md">
         <div className="flex justify-end p-2">
           <form action="/api/register/export" method="post">
-            <button className="border rounded px-3 py-2 text-sm" type="submit">Export CSV</button>
+            <Button className="border px-3 py-2 text-sm" type="submit" variant="outline" size="sm">
+              Export CSV
+            </Button>
           </form>
         </div>
         <table className="w-full text-sm">

--- a/app/(authenticated)/dashboard/reporting-channels/[id]/page.tsx
+++ b/app/(authenticated)/dashboard/reporting-channels/[id]/page.tsx
@@ -8,6 +8,7 @@ import { setChannelDefaultLanguage, deleteReportingChannelAction } from "@/actio
 import { CopyButton } from "@/components/ui/copy-button"
 import { Link as LinkIcon, ExternalLink, Copy as CopyIcon, Image as ImageIcon } from "lucide-react"
 import { clerkClient } from "@clerk/nextjs/server"
+import { Button } from "tweakcn/ui/button"
 
 export default async function ReportingChannelDetail({ params }: { params: Promise<{ id: string }> }) {
 	const { orgId: clerkOrgId } = await auth()
@@ -36,9 +37,15 @@ export default async function ReportingChannelDetail({ params }: { params: Promi
 			</div>
         <div className="space-y-4">
           <div className="flex items-center gap-4 border-b">
-            <button className="border-b-2 border-primary px-3 py-2 text-sm font-medium">Links</button>
-            <button className="px-3 py-2 text-sm text-muted-foreground" disabled>Phone hotline</button>
-            <button className="px-3 py-2 text-sm text-muted-foreground" disabled>Email</button>
+            <Button className="border-b-2 border-primary font-medium" variant="link" size="sm">
+              Links
+            </Button>
+            <Button className="text-muted-foreground" variant="link" size="sm" disabled>
+              Phone hotline
+            </Button>
+            <Button className="text-muted-foreground" variant="link" size="sm" disabled>
+              Email
+            </Button>
           </div>
         </div>
         <div className="grid gap-6 lg:grid-cols-2">
@@ -81,7 +88,9 @@ export default async function ReportingChannelDetail({ params }: { params: Promi
                 )}
                 <form action={async (formData: FormData) => {"use server"}} className="flex items-center gap-2">
                   <input type="file" name="logo" accept="image/*" className="text-xs" />
-                  <button type="submit" className="rounded bg-primary px-2 py-1 text-primary-foreground">Upload</button>
+                  <Button type="submit" className="px-2 py-1" variant="primary" size="sm">
+                    Upload
+                  </Button>
                 </form>
               </div>
             </div>
@@ -104,7 +113,9 @@ export default async function ReportingChannelDetail({ params }: { params: Promi
                                     <option value="en">English</option>
                                     <option value="pl">Polski</option>
                                 </select>
-                                <button type="submit" className="rounded bg-primary px-2 py-1 text-primary-foreground">Save</button>
+                                <Button type="submit" className="px-2 py-1" variant="primary" size="sm">
+                                  Save
+                                </Button>
                             </form>
 							</div>
 						</div>
@@ -122,7 +133,9 @@ export default async function ReportingChannelDetail({ params }: { params: Promi
 							</div>
                         <form action={deleteReportingChannelAction} className="pt-2">
                             <input type="hidden" name="id" value={channel.id} />
-                            <button type="submit" className="rounded border px-3 py-2 text-sm text-destructive">Delete channel</button>
+                            <Button type="submit" className="px-3 py-2 text-sm" variant="destructive" size="sm">
+                              Delete channel
+                            </Button>
                         </form>
 						</div>
 					</div>

--- a/app/(authenticated)/dashboard/reporting-channels/[id]/poster/page.tsx
+++ b/app/(authenticated)/dashboard/reporting-channels/[id]/poster/page.tsx
@@ -4,6 +4,7 @@ import { db } from "@/db"
 import { reportingChannels } from "@/db/schema/reportingChannels"
 import { organizations } from "@/db/schema/organizations"
 import { eq } from "drizzle-orm"
+import { Button } from "tweakcn/ui/button"
 
 export default async function PosterPage({ params }: { params: { id: string } }) {
   const channel = await db.query.reportingChannels.findFirst({ where: eq(reportingChannels.id, params.id) })
@@ -29,9 +30,9 @@ export default async function PosterPage({ params }: { params: { id: string } })
           >
             Back
           </a>
-          <button className="btn btn-primary">
+          <Button className="btn btn-primary" variant="primary" size="sm">
             <span>Print</span>
-          </button>
+          </Button>
         </div>
         <div className="page bg-card rounded-lg shadow-lg p-8 max-w-3xl mx-auto">
           <div className="flex items-center gap-4 mb-6">

--- a/app/(authenticated)/dashboard/reporting-channels/page.tsx
+++ b/app/(authenticated)/dashboard/reporting-channels/page.tsx
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm"
 import Link from "next/link"
 import { CopyButton } from "@/components/ui/copy-button"
 import { Link as LinkIcon, ExternalLink, QrCode } from "lucide-react"
+import { Button } from "tweakcn/ui/button"
 
 export default async function ReportingChannelsPage() {
 	const { orgId: clerkOrgId } = await auth()
@@ -19,9 +20,15 @@ export default async function ReportingChannelsPage() {
 	return (
     <div className="space-y-6">
       <div className="flex items-center gap-4 border-b">
-        <button className="border-b-2 border-primary px-3 py-2 text-sm font-medium">Links</button>
-        <button className="px-3 py-2 text-sm text-muted-foreground" disabled>Phone hotline</button>
-        <button className="px-3 py-2 text-sm text-muted-foreground" disabled>Email</button>
+        <Button className="border-b-2 border-primary font-medium" variant="link" size="sm">
+          Links
+        </Button>
+        <Button className="text-muted-foreground" variant="link" size="sm" disabled>
+          Phone hotline
+        </Button>
+        <Button className="text-muted-foreground" variant="link" size="sm" disabled>
+          Email
+        </Button>
       </div>
 			<div className="flex items-center justify-between">
 				<h1 className="text-2xl font-semibold">Reporting channels</h1>

--- a/app/(authenticated)/dashboard/settings/page.tsx
+++ b/app/(authenticated)/dashboard/settings/page.tsx
@@ -5,6 +5,7 @@ import { organizations } from "@/db/schema/organizations"
 import { eq } from "drizzle-orm"
 import { updateOrgSettings } from "@/src/server/services/settings"
 import { addCategory, setCategoryActive } from "@/actions/categories"
+import { Button } from "tweakcn/ui/button"
 
 export default async function SettingsPage() {
   const { orgId: clerkOrgId } = await auth()
@@ -58,7 +59,9 @@ export default async function SettingsPage() {
             <label htmlFor="anonymousAllowed" className="text-sm">Allow anonymous reports</label>
           </div>
           <div>
-            <button type="submit" className="rounded bg-primary px-3 py-2 text-sm text-primary-foreground">Save</button>
+            <Button type="submit" className="px-3 py-2 text-sm" variant="primary" size="sm">
+              Save
+            </Button>
           </div>
         </form>
       </section>
@@ -83,7 +86,9 @@ export default async function SettingsPage() {
                 <label className="text-xs text-muted-foreground">Name</label>
                 <input name="name" className="rounded border px-2 py-1" placeholder="Category name" />
               </div>
-              <button type="submit" className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground">Save</button>
+              <Button type="submit" className="px-3 py-1 text-sm" variant="primary" size="sm">
+                Save
+              </Button>
             </form>
           </div>
         </details>
@@ -103,7 +108,9 @@ export default async function SettingsPage() {
                   <td className="p-2">{c.active ? "Active" : "Inactive"}</td>
                   <td className="p-2">
                     <form action={async () => { "use server"; await setCategoryActive(c.id, !c.active) }}>
-                      <button type="submit" className="rounded border px-2 py-1 text-xs">{c.active ? "Deactivate" : "Activate"}</button>
+                      <Button type="submit" className="px-2 py-1 text-xs" variant="outline" size="sm">
+                        {c.active ? "Deactivate" : "Activate"}
+                      </Button>
                     </form>
                   </td>
                 </tr>

--- a/app/(authenticated)/dashboard/statistics/stats-client.tsx
+++ b/app/(authenticated)/dashboard/statistics/stats-client.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
+import { Button } from "tweakcn/ui/button"
 import {
   Bar,
   CartesianGrid,
@@ -67,14 +68,16 @@ export default function ChartsClient({ kpis, volume, lifecycle, categoryRisk }: 
         <div className="mb-2 text-sm font-medium">Cases by month (stacked by category)</div>
         <div className="flex flex-wrap gap-2 text-xs">
           {topCats.map((c: string) => (
-            <button
+            <Button
               key={c}
               onMouseEnter={() => setHoverCategory(c)}
               onMouseLeave={() => setHoverCategory(null)}
-              className={`rounded border px-2 py-1 ${hoverCategory === c ? "bg-primary text-white" : "bg-background"}`}
+              className={`${hoverCategory === c ? "bg-primary text-white" : "bg-background"} px-2 py-1`}
+              variant="outline"
+              size="sm"
             >
               {c}
-            </button>
+            </Button>
           ))}
         </div>
         <div className="h-72">

--- a/app/(authenticated)/dashboard/surveys/new/wizard-client.tsx
+++ b/app/(authenticated)/dashboard/surveys/new/wizard-client.tsx
@@ -1,15 +1,21 @@
 "use client"
 
 import { useState } from "react"
-import { Button } from "@/components/ui/button"
+import { Button } from "tweakcn/ui/button"
 
 function StepHeader({ step, setStep }: { step: number; setStep: (n: number) => void }) {
   return (
     <div className="flex items-center gap-4 border-b pb-2">
       {["Welcome", "Survey", "Thank you"].map((label, i) => (
-        <button key={label} className={`text-sm ${step === i ? "font-semibold" : "text-muted-foreground"}`} onClick={() => setStep(i)}>
+        <Button
+          key={label}
+          className={`text-sm ${step === i ? "font-semibold" : "text-muted-foreground"}`}
+          onClick={() => setStep(i)}
+          variant="link"
+          size="sm"
+        >
           {i + 1}. {label}
-        </button>
+        </Button>
       ))}
     </div>
   )

--- a/app/(unauthenticated)/(marketing)/_components/header.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/header.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Button } from "@/components/ui/button"
+import { Button } from "tweakcn/ui/button"
 import { SelectCustomer } from "@/db/schema/customers"
 import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs"
 import { Menu, Moon, Sun, X, Sparkles } from "lucide-react"
@@ -41,10 +41,12 @@ export function Header({ userMembership }: HeaderProps) {
             </Link>
           </div>
           <div className="flex lg:hidden">
-            <button
+            <Button
               type="button"
-              className="text-muted-foreground -m-2.5 inline-flex items-center justify-center rounded-md p-2.5"
+              className="-m-2.5 inline-flex items-center justify-center p-2.5 text-muted-foreground"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              variant="ghost"
+              size="icon"
             >
               <span className="sr-only">Open main menu</span>
               {mobileMenuOpen ? (
@@ -52,7 +54,7 @@ export function Header({ userMembership }: HeaderProps) {
               ) : (
                 <Menu className="h-6 w-6" aria-hidden="true" />
               )}
-            </button>
+            </Button>
           </div>
           <div className="hidden lg:flex lg:gap-x-12">
             {navigation.map(item => (
@@ -124,14 +126,16 @@ export function Header({ userMembership }: HeaderProps) {
               >
                 <span className="text-xl font-bold">Signalista</span>
               </Link>
-              <button
+              <Button
                 type="button"
-                className="text-muted-foreground -m-2.5 rounded-md p-2.5"
+                className="-m-2.5 rounded-md p-2.5 text-muted-foreground"
                 onClick={() => setMobileMenuOpen(false)}
+                variant="ghost"
+                size="icon"
               >
                 <span className="sr-only">Close menu</span>
                 <X className="h-6 w-6" aria-hidden="true" />
-              </button>
+              </Button>
             </div>
             <div className="mt-6 flow-root">
               <div className="divide-border -my-6 divide-y">

--- a/app/(unauthenticated)/(marketing)/_components/site-banner.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/site-banner.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from "framer-motion"
 import { ArrowRight, X } from "lucide-react"
 import Link from "next/link"
 import { useState } from "react"
+import { Button } from "tweakcn/ui/button"
 
 export function SiteBanner() {
   const [isVisible, setIsVisible] = useState(true)
@@ -33,13 +34,15 @@ export function SiteBanner() {
                   <ArrowRight className="ml-1 h-3.5 w-3.5" />
                 </Link>
               </div>
-              <button
+              <Button
                 onClick={handleDismiss}
                 className="absolute right-0 rounded p-1 transition-colors hover:bg-white/10"
                 aria-label="Dismiss banner"
+                variant="ghost"
+                size="icon"
               >
                 <X className="h-4 w-4" />
-              </button>
+              </Button>
             </div>
           </div>
         </motion.div>

--- a/app/(unauthenticated)/(marketing)/_components/sticky-cta.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/sticky-cta.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Button } from "@/components/ui/button"
+import { Button } from "tweakcn/ui/button"
 import { AnimatePresence, motion } from "framer-motion"
 import { ArrowRight } from "lucide-react"
 import Link from "next/link"
@@ -40,10 +40,12 @@ export function StickyCTA() {
                 </Link>
               </Button>
               {/* Close button */}
-              <button
+              <Button
                 aria-label="Dismiss"
                 onClick={() => setDismissed(true)}
-                className="hover:bg-accent ml-2 rounded-full p-1"
+                className="ml-2 rounded-full p-1 hover:bg-accent"
+                variant="ghost"
+                size="icon"
               >
                 <svg width="16" height="16" fill="none" viewBox="0 0 16 16">
                   <path
@@ -54,7 +56,7 @@ export function StickyCTA() {
                     d="M4 4l8 8m0-8l-8 8"
                   />
                 </svg>
-              </button>
+              </Button>
             </div>
           </motion.div>
 
@@ -66,10 +68,12 @@ export function StickyCTA() {
             transition={{ type: "spring", stiffness: 300, damping: 30 }}
             className="border-border bg-card fixed right-6 bottom-6 z-50 hidden max-w-sm min-w-[300px] rounded-lg border p-6 shadow-xl md:block"
           >
-            <button
+            <Button
               aria-label="Dismiss"
               onClick={() => setDismissed(true)}
-              className="hover:bg-accent absolute top-3 right-3 rounded-full p-1"
+              className="absolute top-3 right-3 rounded-full p-1 hover:bg-accent"
+              variant="ghost"
+              size="icon"
             >
               <svg width="18" height="18" fill="none" viewBox="0 0 18 18">
                 <path
@@ -80,7 +84,7 @@ export function StickyCTA() {
                   d="M5 5l8 8m0-8l-8 8"
                 />
               </svg>
-            </button>
+            </Button>
             <div className="space-y-4">
               <div>
                 <p className="text-muted-foreground text-sm font-medium">

--- a/app/(unauthenticated)/reporting-channel/[slug]/client-landing.tsx
+++ b/app/(unauthenticated)/reporting-channel/[slug]/client-landing.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import ReportForm from "@/components/report/report-form"
+import { Button } from "tweakcn/ui/button"
 
 type Props = {
   orgName: string
@@ -60,9 +61,9 @@ export default function ReportLandingClient({ orgName, channelSlug, categories, 
           </section>
 
           <div className="flex items-center gap-2">
-            <button onClick={() => setStarted(true)} className="inline-flex rounded bg-primary px-4 py-2 text-primary-foreground">
+            <Button onClick={() => setStarted(true)} className="px-4 py-2" variant="primary" size="sm">
               Create New Report
-            </button>
+            </Button>
             <a
               href={`/reporting-channel/${encodeURIComponent(channelSlug)}/checkcase`}
               onClick={(e) => {

--- a/components/report/report-form.tsx
+++ b/components/report/report-form.tsx
@@ -4,10 +4,9 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { z } from "zod"
 import Script from "next/script"
 import { reportIntakeSchema, type ReportIntake } from "@/lib/validation/report"
-import { Button } from "@/components/ui/button"
+import { Button } from "tweakcn/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Input } from "@/components/ui/input"
-import { Button as UIButton } from "@/components/ui/button"
 import { getBrowserSupabase } from "@/lib/supabase/client"
 
 async function sha256(file: File): Promise<string> {
@@ -366,27 +365,31 @@ export default function ReportForm({
           Choose how you would like to report
         </label>
         <div className="grid gap-2 md:grid-cols-2">
-          <button
+          <Button
             type="button"
             className={`rounded border p-3 text-left ${!values.anonymous ? "border-primary" : ""}`}
             onClick={() => setField("anonymous", false)}
+            variant="outline"
+            size="sm"
           >
             <div className="font-medium">Report Confidentially</div>
             <div className="text-muted-foreground text-sm">
               Provide optional contact so handlers can reach you.
             </div>
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             className={`rounded border p-3 text-left ${values.anonymous ? "border-primary" : ""}`}
             onClick={() => setField("anonymous", true)}
+            variant="outline"
+            size="sm"
           >
             <div className="font-medium">Report Anonymously</div>
             <div className="text-muted-foreground text-sm">
               Do not share identifying information; you will receive a receipt
               and passphrase.
             </div>
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -448,13 +451,14 @@ export default function ReportForm({
               })
             }}
           />
-          <UIButton
+          <Button
             type="button"
             variant="secondary"
+            size="sm"
             onClick={() => document.getElementById("file-input")?.click()}
           >
             Choose files
-          </UIButton>
+          </Button>
           {files.length > 0 && (
             <span className="text-muted-foreground text-sm">
               {files.length} file(s) selected
@@ -474,9 +478,11 @@ export default function ReportForm({
                     ({Math.ceil(f.size / 1024)} KB)
                   </span>
                 </span>
-                <button
+                <Button
                   type="button"
                   className="text-xs text-red-600"
+                  variant="link"
+                  size="sm"
                   onClick={() =>
                     setFiles(prev => {
                       const next = prev.filter((_, i) => i !== idx)
@@ -493,7 +499,7 @@ export default function ReportForm({
                   }
                 >
                   Remove
-                </button>
+                </Button>
               </li>
             ))}
           </ul>
@@ -514,13 +520,15 @@ export default function ReportForm({
               </div>
             </div>
             {audioUrl && (
-              <button
+              <Button
                 type="button"
                 className="text-xs text-red-600"
                 onClick={removeVoiceAttachment}
+                variant="link"
+                size="sm"
               >
                 Remove
-              </button>
+              </Button>
             )}
           </div>
 
@@ -538,21 +546,23 @@ export default function ReportForm({
               {String(recordSeconds % 60).padStart(2, "0")}
             </div>
             {!isRecording ? (
-              <UIButton
+              <Button
                 type="button"
                 onClick={startRecording}
                 variant="default"
+                size="sm"
               >
                 Start recording
-              </UIButton>
+              </Button>
             ) : (
-              <UIButton
+              <Button
                 type="button"
                 onClick={stopRecording}
                 variant="destructive"
+                size="sm"
               >
                 Stop
-              </UIButton>
+              </Button>
             )}
           </div>
 
@@ -609,7 +619,7 @@ export default function ReportForm({
         </div>
       )}
 
-      <Button type="submit" disabled={submitting}>
+      <Button type="submit" disabled={submitting} variant="primary" size="sm">
         {submitting ? "Submitting..." : "Submit report"}
       </Button>
 

--- a/components/ui/copy-button.tsx
+++ b/components/ui/copy-button.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import { Check, Copy as CopyIcon } from "lucide-react"
+import { Button } from "tweakcn/ui/button"
 
 export function CopyButton({ text, className, iconOnly }: { text: string; className?: string; iconOnly?: boolean }) {
 	const [copied, setCopied] = useState(false)
@@ -14,15 +15,23 @@ export function CopyButton({ text, className, iconOnly }: { text: string; classN
 		} catch {}
 	}
 
-	return (
-		<button type="button" onClick={onCopy} className={className} aria-live="polite" title={copied ? "Copied" : "Copy"}>
-			{iconOnly ? (
-				copied ? <Check className="h-4 w-4" /> : <CopyIcon className="h-4 w-4" />
-			) : (
-				copied ? "Copied" : "Copy"
-			)}
-		</button>
-	)
+        return (
+                <Button
+                        type="button"
+                        onClick={onCopy}
+                        className={className}
+                        aria-live="polite"
+                        title={copied ? "Copied" : "Copy"}
+                        variant="ghost"
+                        size={iconOnly ? "icon" : "sm"}
+                >
+                        {iconOnly ? (
+                                copied ? <Check className="h-4 w-4" /> : <CopyIcon className="h-4 w-4" />
+                        ) : (
+                                copied ? "Copied" : "Copy"
+                        )}
+                </Button>
+        )
 }
 
 

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -7,7 +7,7 @@ import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { Button } from "tweakcn/ui/button"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import {
@@ -283,7 +283,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar()
 
   return (
-    <button
+    <Button
       data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label="Toggle Sidebar"
@@ -299,6 +299,8 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
         "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
         className
       )}
+      variant="ghost"
+      size="icon"
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- replace native button elements with `Button` component from `tweakcn/ui/button`
- ensure each button declares `variant` and `size`
- standardize UI interactions across marketing and dashboard pages

## Testing
- `npm test` *(fails: DATABASE_URL is not set; clerkClient mock missing)*
- `npm run lint` *(fails: numerous @typescript-eslint/no-explicit-any and next/no-html-link-for-pages errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af696f15988321903aa4e7936e41aa