### PR TITLE
feat: add dialog for case thread

### DIFF
--- a/app/(authenticated)/dashboard/cases/[id]/client-thread.tsx
+++ b/app/(authenticated)/dashboard/cases/[id]/client-thread.tsx
@@ -4,6 +4,9 @@ import { useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Dialog, DialogTrigger, DialogContent } from "tweakcn/ui/dialog"
+import { Card } from "tweakcn/ui/card"
+import { Checkbox } from "tweakcn/ui/checkbox"
 
 type ThreadItem = {
   id: string
@@ -100,72 +103,83 @@ export default function CaseThreadClient({ reportId, initialThread }: Props) {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex gap-2">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="outline" size="sm" onClick={acknowledge} disabled={actionLoading !== null}>
-              {actionLoading === "ack" ? "Acknowledging..." : "Acknowledge"}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Mark case as acknowledged</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="outline" size="sm" onClick={giveFeedback} disabled={actionLoading !== null}>
-              {actionLoading === "feedback" ? "Saving..." : "Feedback given"}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Mark follow-up communication as sent</TooltipContent>
-        </Tooltip>
-      </div>
-
-      <div className="space-y-3">
-        {thread.map((m) => (
-          <div key={m.id} className="rounded border p-3">
-            <div className="mb-1 text-xs text-muted-foreground">
-              {m.sender} • {new Date(m.createdAt).toLocaleString()}
-            </div>
-            <div className="whitespace-pre-wrap flex items-start gap-2">
-              <span className="mt-1 inline-block" aria-hidden>📎</span>
-              <span>{m.body}</span>
-            </div>
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">Open conversation</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[600px]">
+        <div className="space-y-6">
+          <div className="flex gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={acknowledge} disabled={actionLoading !== null}>
+                  {actionLoading === "ack" ? "Acknowledging..." : "Acknowledge"}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Mark case as acknowledged</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={giveFeedback} disabled={actionLoading !== null}>
+                  {actionLoading === "feedback" ? "Saving..." : "Feedback given"}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Mark follow-up communication as sent</TooltipContent>
+            </Tooltip>
           </div>
-        ))}
-      </div>
 
-      <div className="space-y-2">
-        <Textarea
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Add a message..."
-          rows={3}
-        />
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <input ref={fileInputRef} type="file" multiple className="block text-sm" onChange={e => setFiles(Array.from(e.target.files || []))} />
-          </TooltipTrigger>
-          <TooltipContent>Attach files (PDF, images, docs)</TooltipContent>
-        </Tooltip>
-        <div className="flex gap-2">
-          <Button size="sm" onClick={sendMessage} disabled={submitting}>
-            {submitting ? "Sending..." : "Send"}
-          </Button>
-        </div>
-          <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              id="anonymousSend"
-              className="h-4 w-4"
-              checked={anonymousSend}
-              onChange={(e) => setAnonymousSend(e.target.checked)}
+          <div className="space-y-3">
+            {thread.map((m) => (
+              <Card key={m.id} className="p-3">
+                <div className="mb-1 text-xs text-muted-foreground">
+                  {m.sender} • {new Date(m.createdAt).toLocaleString()}
+                </div>
+                <div className="whitespace-pre-wrap flex items-start gap-2">
+                  <span className="mt-1 inline-block" aria-hidden>📎</span>
+                  <span>{m.body}</span>
+                </div>
+              </Card>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            <Textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Add a message..."
+              rows={3}
             />
-            <label htmlFor="anonymousSend" className="text-sm text-muted-foreground">
-              Do not display my name to the sender
-            </label>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  className="block text-sm"
+                  onChange={e => setFiles(Array.from(e.target.files || []))}
+                />
+              </TooltipTrigger>
+              <TooltipContent>Attach files (PDF, images, docs)</TooltipContent>
+            </Tooltip>
+            <div className="flex gap-2">
+              <Button size="sm" onClick={sendMessage} disabled={submitting}>
+                {submitting ? "Sending..." : "Send"}
+              </Button>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="anonymousSend"
+                checked={anonymousSend}
+                onCheckedChange={(checked) => setAnonymousSend(!!checked)}
+              />
+              <label htmlFor="anonymousSend" className="text-sm text-muted-foreground">
+                Do not display my name to the sender
+              </label>
+            </div>
           </div>
-      </div>
-    </div>
+        </div>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-background/80 backdrop-blur-sm", className)}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+export { Dialog, DialogTrigger, DialogContent, DialogClose }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,13 +13,15 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
     "plugins": [
       {
         "name": "next"
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "tweakcn/*": ["components/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,11 +2,12 @@ import { defineConfig } from "vitest/config"
 import path from "path"
 
 export default defineConfig({
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname),
-		},
-	},
+        resolve: {
+                alias: {
+                        "@": path.resolve(__dirname),
+                        "tweakcn": path.resolve(__dirname, "components"),
+                },
+        },
 	test: {
 		environment: "node",
 		include: [


### PR DESCRIPTION
## Summary
- wrap case conversation and composer in Tweakcn Dialog
- show messages with Card bubbles and anonymity Checkbox
- add Dialog primitive and tweakcn alias support

## Testing
- `npm test` *(fails: DATABASE_URL is not set; clerkClient mock missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af68fc1d688321acc220151e2f02f8