### PR TITLE
refactor: use tweakcn form components

### DIFF
--- a/app/(authenticated)/dashboard/members/user/[id]/profile-editor.tsx
+++ b/app/(authenticated)/dashboard/members/user/[id]/profile-editor.tsx
@@ -3,6 +3,13 @@
 import { useState } from "react"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 export default function MemberEditor({ id, name, email, role, phone, clerkId }: { id: string; name: string; email: string; role: "ADMIN" | "HANDLER" | "AUDITOR"; phone: string; clerkId: string }) {
   const [firstName, setFirst] = useState(name.split(" ")[0] || "")
@@ -74,11 +81,16 @@ export default function MemberEditor({ id, name, email, role, phone, clerkId }: 
         <div className="text-sm font-medium">Permissions</div>
         <div>
           <div className="text-xs text-muted-foreground mb-1">Role</div>
-          <select className="w-full rounded-md border px-2 py-2" value={memberRole} onChange={e => setMemberRole(e.target.value as any)}>
-            <option value="ADMIN">Administrator</option>
-            <option value="HANDLER">Handler</option>
-            <option value="AUDITOR">Auditor</option>
-          </select>
+          <Select value={memberRole} onValueChange={value => setMemberRole(value as any)}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select a role" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ADMIN">Administrator</SelectItem>
+              <SelectItem value="HANDLER">Handler</SelectItem>
+              <SelectItem value="AUDITOR">Auditor</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         <div className="flex gap-2">
           <Button variant="outline" onClick={saveRole} disabled={saving}>Update role</Button>

--- a/app/(authenticated)/dashboard/settings/page.tsx
+++ b/app/(authenticated)/dashboard/settings/page.tsx
@@ -5,6 +5,18 @@ import { organizations } from "@/db/schema/organizations"
 import { eq } from "drizzle-orm"
 import { updateOrgSettings } from "@/src/server/services/settings"
 import { addCategory, setCategoryActive } from "@/actions/categories"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Input } from "@/components/ui/input"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardFooter } from "@/components/ui/card"
 
 export default async function SettingsPage() {
   const { orgId: clerkOrgId } = await auth()
@@ -20,46 +32,82 @@ export default async function SettingsPage() {
       <h1 className="text-2xl font-semibold">Settings</h1>
       <section className="space-y-3">
         <h2 className="text-lg font-semibold">Organization</h2>
-        <form action={async (formData: FormData) => {
-          "use server"
-          const name = String(formData.get("name") || "").trim()
-          const locale = String(formData.get("locale") || "pl-PL")
-          const retention = Number(formData.get("retentionDays") || 365)
-          const anonymousAllowed = !!formData.get("anonymousAllowed")
-          const ackDays = Number(formData.get("ackDays") || 7)
-          const feedbackMonths = Number(formData.get("feedbackMonths") || 3)
-          await updateOrgSettings(orgId, { name, locale, retentionDays: retention, anonymousAllowed, ackDays, feedbackMonths })
-        }} className="rounded border p-4 grid gap-3 text-sm">
-          <div className="grid gap-1">
-            <label className="text-muted-foreground">Name</label>
-            <input name="name" defaultValue={org?.name || ""} className="rounded border px-2 py-1" />
-          </div>
-          <div className="grid gap-1">
-            <label className="text-muted-foreground">Default language</label>
-            <select name="locale" defaultValue={org?.locale || "pl-PL"} className="rounded border px-2 py-1 max-w-xs">
-              <option value="en-US">English</option>
-              <option value="pl-PL">Polski</option>
-            </select>
-          </div>
-          <div className="grid gap-1 max-w-xs">
-            <label className="text-muted-foreground">Retention (days)</label>
-            <input type="number" name="retentionDays" defaultValue={org?.retentionDays || 365} className="rounded border px-2 py-1" />
-          </div>
-          <div className="grid gap-1 max-w-xs">
-            <label className="text-muted-foreground">Acknowledge window (days)</label>
-            <input type="number" name="ackDays" defaultValue={(org as any)?.ackDays ?? 7} className="rounded border px-2 py-1" />
-          </div>
-          <div className="grid gap-1 max-w-xs">
-            <label className="text-muted-foreground">Feedback window (months)</label>
-            <input type="number" name="feedbackMonths" defaultValue={(org as any)?.feedbackMonths ?? 3} className="rounded border px-2 py-1" />
-          </div>
-          <div className="flex items-center gap-2">
-            <input id="anonymousAllowed" type="checkbox" name="anonymousAllowed" defaultChecked={org?.anonymousAllowed ?? true} className="rounded border" />
-            <label htmlFor="anonymousAllowed" className="text-sm">Allow anonymous reports</label>
-          </div>
-          <div>
-            <button type="submit" className="rounded bg-primary px-3 py-2 text-sm text-primary-foreground">Save</button>
-          </div>
+        <form
+          action={async (formData: FormData) => {
+            "use server"
+            const name = String(formData.get("name") || "").trim()
+            const locale = String(formData.get("locale") || "pl-PL")
+            const retention = Number(formData.get("retentionDays") || 365)
+            const anonymousAllowed = !!formData.get("anonymousAllowed")
+            const ackDays = Number(formData.get("ackDays") || 7)
+            const feedbackMonths = Number(formData.get("feedbackMonths") || 3)
+            await updateOrgSettings(orgId, {
+              name,
+              locale,
+              retentionDays: retention,
+              anonymousAllowed,
+              ackDays,
+              feedbackMonths,
+            })
+          }}
+        >
+          <Card className="grid gap-3 text-sm">
+            <CardContent className="grid gap-3">
+              <div className="grid gap-1">
+                <Label className="text-muted-foreground">Name</Label>
+                <Input name="name" defaultValue={org?.name || ""} />
+              </div>
+              <div className="grid gap-1">
+                <Label className="text-muted-foreground">Default language</Label>
+                <Select name="locale" defaultValue={org?.locale || "pl-PL"}>
+                  <SelectTrigger className="max-w-xs">
+                    <SelectValue placeholder="Select language" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="en-US">English</SelectItem>
+                    <SelectItem value="pl-PL">Polski</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-1 max-w-xs">
+                <Label className="text-muted-foreground">Retention (days)</Label>
+                <Input
+                  type="number"
+                  name="retentionDays"
+                  defaultValue={org?.retentionDays || 365}
+                />
+              </div>
+              <div className="grid gap-1 max-w-xs">
+                <Label className="text-muted-foreground">Acknowledge window (days)</Label>
+                <Input
+                  type="number"
+                  name="ackDays"
+                  defaultValue={(org as any)?.ackDays ?? 7}
+                />
+              </div>
+              <div className="grid gap-1 max-w-xs">
+                <Label className="text-muted-foreground">Feedback window (months)</Label>
+                <Input
+                  type="number"
+                  name="feedbackMonths"
+                  defaultValue={(org as any)?.feedbackMonths ?? 3}
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="anonymousAllowed"
+                  name="anonymousAllowed"
+                  defaultChecked={org?.anonymousAllowed ?? true}
+                />
+                <Label htmlFor="anonymousAllowed" className="text-sm">
+                  Allow anonymous reports
+                </Label>
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Button type="submit">Save</Button>
+            </CardFooter>
+          </Card>
         </form>
       </section>
 
@@ -75,18 +123,20 @@ export default async function SettingsPage() {
 
       <section className="space-y-3">
         <h2 className="text-lg font-semibold">Categories</h2>
-        <details className="rounded border p-4">
-          <summary className="cursor-pointer text-sm font-medium">Add category</summary>
-          <div className="mt-3">
-            <form action={addCategory} className="flex gap-2 items-end">
+        <Card>
+          <details className="p-4">
+            <summary className="cursor-pointer text-sm font-medium">Add category</summary>
+            <form action={addCategory} className="mt-3 flex items-end gap-2">
               <div className="grid gap-1">
-                <label className="text-xs text-muted-foreground">Name</label>
-                <input name="name" className="rounded border px-2 py-1" placeholder="Category name" />
+                <Label className="text-xs text-muted-foreground">Name</Label>
+                <Input name="name" placeholder="Category name" />
               </div>
-              <button type="submit" className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground">Save</button>
+              <Button type="submit" size="sm">
+                Save
+              </Button>
             </form>
-          </div>
-        </details>
+          </details>
+        </Card>
         <div className="rounded border">
           <table className="w-full text-sm">
             <thead className="bg-muted">
@@ -103,7 +153,9 @@ export default async function SettingsPage() {
                   <td className="p-2">{c.active ? "Active" : "Inactive"}</td>
                   <td className="p-2">
                     <form action={async () => { "use server"; await setCategoryActive(c.id, !c.active) }}>
-                      <button type="submit" className="rounded border px-2 py-1 text-xs">{c.active ? "Deactivate" : "Activate"}</button>
+                      <Button type="submit" variant="outline" size="sm">
+                        {c.active ? "Deactivate" : "Activate"}
+                      </Button>
                     </form>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- replace native form controls with Tweakcn Select, Input, Checkbox and Button primitives
- wrap settings forms with Card and style category actions consistently
- update profile editor to use Select for role management

## Testing
- `npm test` *(fails: DATABASE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68af692184f0832190848e0bd956b5c3