### PR TITLE
Add assignment and date filters to cases table

### DIFF
--- a/app/(authenticated)/dashboard/cases/data-picker-with-range.tsx
+++ b/app/(authenticated)/dashboard/cases/data-picker-with-range.tsx
@@ -1,33 +1,33 @@
 "use client"
 
-import { addDays, format } from "date-fns"
+import { format } from "date-fns"
 import { Calendar as CalendarIcon } from "lucide-react"
 import * as React from "react"
 import { DateRange } from "react-day-picker"
 
 import { Button } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle
-} from "@/components/ui/card"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger
-} from "@/components/ui/popover"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
 
 export function DatePickerWithRange({
-  className
-}: React.HTMLAttributes<HTMLDivElement>) {
-  const [date, setDate] = React.useState<DateRange | undefined>({
-    from: new Date(2022, 0, 20),
-    to: addDays(new Date(2022, 0, 20), 20)
-  })
+  className,
+  value,
+  onChange
+}: React.HTMLAttributes<HTMLDivElement> & {
+  value?: DateRange
+  onChange?: (value: DateRange | undefined) => void
+}) {
+  const [date, setDate] = React.useState<DateRange | undefined>(value)
+
+  React.useEffect(() => {
+    setDate(value)
+  }, [value])
+
+  const handleSelect = (range: DateRange | undefined) => {
+    setDate(range)
+    onChange?.(range)
+  }
 
   return (
     <Popover>
@@ -60,7 +60,7 @@ export function DatePickerWithRange({
           mode="range"
           defaultMonth={date?.from}
           selected={date}
-          onSelect={setDate}
+          onSelect={handleSelect}
           numberOfMonths={2}
         />
       </PopoverContent>

--- a/app/(authenticated)/dashboard/cases/page.tsx
+++ b/app/(authenticated)/dashboard/cases/page.tsx
@@ -1,12 +1,10 @@
 import { auth } from "@clerk/nextjs/server"
 import { listCases, getCaseSummary } from "@/src/server/services/cases"
-import { CaseTable } from "@/components/cases/case-table"
 import { db } from "@/db"
 import { reportCategories } from "@/db/schema/reportCategories"
 import { CasesControls } from "./cases-controls"
 import { eq } from "drizzle-orm"
 import { DataTable } from "../_components/data-table"
-import { DatePickerWithRange } from "./data-picker-with-range"
 
 export default async function CasesPage({
   searchParams


### PR DESCRIPTION
## Summary
- show all cases by default and allow filtering by assignment (all / assigned to me / unassigned)
- enable date range filtering with functional calendar control

## Testing
- `npm run lint` *(fails: Unexpected any across repository)*
- `npm test` *(fails: database connection errors / missing mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68b08f13843c832181b666790ada09fd