### PR TITLE
Track reporter case view timestamps

### DIFF
--- a/app/(authenticated)/dashboard/cases/[id]/info-panel.tsx
+++ b/app/(authenticated)/dashboard/cases/[id]/info-panel.tsx
@@ -20,10 +20,12 @@ function toLocal(d: Date | string | null | undefined) {
 
 export default function InfoPanel({
   report,
-  orgName
+  orgName,
+  lastViewedByReporter
 }: {
   report: SelectReport
   orgName: string
+  lastViewedByReporter: Date | string | null
 }) {
   // 2) Local state for optimistic UI (fall back to a valid default if status is missing)
   const initialStatus = (report.status as ReportStatus | undefined) ?? "NEW"
@@ -104,6 +106,10 @@ export default function InfoPanel({
           value: toLocal((report as any).acknowledgedAt)
         },
         {
+          label: "Last reporter view",
+          value: toLocal(lastViewedByReporter)
+        },
+        {
           label: "Assignees",
           value: assignees.map(a => initials(a)).join(", ")
         },
@@ -115,6 +121,7 @@ export default function InfoPanel({
       status,
       report.createdAt,
       (report as any).acknowledgedAt,
+      lastViewedByReporter,
       orgName,
       assignees
     ]

--- a/app/(authenticated)/dashboard/cases/[id]/page.tsx
+++ b/app/(authenticated)/dashboard/cases/[id]/page.tsx
@@ -3,7 +3,8 @@ import { reports } from "@/db/schema/reports"
 import { reportMessages } from "@/db/schema/reportMessages"
 import { reportCategories } from "@/db/schema/reportCategories"
 import { reportLogs } from "@/db/schema/reportLogs"
-import { eq, asc } from "drizzle-orm"
+import { reportViews } from "@/db/schema/reportViews"
+import { eq, asc, desc } from "drizzle-orm"
 import { orgMembers } from "@/db/schema/orgMembers"
 import { users } from "@/db/schema/users"
 import { decryptField } from "@/lib/crypto/encryption"
@@ -90,6 +91,14 @@ export default async function CaseViewPage({
       .where(eq(organizations.id, report.orgId))
   )[0].name
 
+  const [lastView] = await db
+    .select({ viewedAt: reportViews.viewedAt })
+    .from(reportViews)
+    .where(eq(reportViews.reportId, report.id))
+    .orderBy(desc(reportViews.viewedAt))
+    .limit(1)
+  const lastReporterView = lastView?.viewedAt ?? null
+
 
   return (
     <div>
@@ -126,7 +135,11 @@ export default async function CaseViewPage({
               <CardTitle className="text-base">Information</CardTitle>
             </CardHeader>
             <CardContent className="p-4 pt-0">
-              <InfoPanel report={report} orgName={orgName} />
+              <InfoPanel
+                report={report}
+                orgName={orgName}
+                lastViewedByReporter={lastReporterView}
+              />
             </CardContent>
           </Card>
 

--- a/app/(unauthenticated)/reporting-channel/[slug]/checkcase/[case]/page.tsx
+++ b/app/(unauthenticated)/reporting-channel/[slug]/checkcase/[case]/page.tsx
@@ -87,6 +87,9 @@ export default function ReporterInboxPage() {
     setReportMeta(data.report)
     setAttachments(data.attachments || [])
     setMessages(data.messages || [])
+    try {
+      await fetch(`/api/reports/${data.report.id}/viewed`, { method: "POST" })
+    } catch {}
   }
 
   async function sendMessage() {

--- a/app/api/reports/[id]/viewed/route.ts
+++ b/app/api/reports/[id]/viewed/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/db"
+import { reportViews } from "@/db/schema/reportViews"
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    await db.insert(reportViews).values({ reportId: id })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/db/index.ts
+++ b/db/index.ts
@@ -17,6 +17,7 @@ import { exportsTable } from "./schema/exports"
 import { surveys, surveyOptions, surveyQuestions } from "./schema/surveys"
 import { onboardingSteps } from "./schema/userOnboarding"
 import { departments } from "./schema/departments"
+import { reportViews } from "./schema/reportViews"
 
 config({ path: ".env.local" })
 
@@ -41,9 +42,10 @@ const dbSchema = {
   reportingChannels,
   surveys,
   surveyQuestions,
-  surveyOptions
-  ,onboardingSteps
-  ,departments
+  surveyOptions,
+  onboardingSteps,
+  departments,
+  reportViews
 }
 
 function initializeDb(url: string) {

--- a/db/migrations/0010_report_views.sql
+++ b/db/migrations/0010_report_views.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "report_views" (
+    "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+    "report_id" uuid NOT NULL,
+    "viewed_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "report_views" ADD CONSTRAINT "report_views_report_id_reports_id_fk" FOREIGN KEY ("report_id") REFERENCES "public"."reports"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "report_views_report_id_idx" ON "report_views" ("report_id");

--- a/db/schema/reportViews.ts
+++ b/db/schema/reportViews.ts
@@ -1,0 +1,12 @@
+import { pgTable, uuid, timestamp } from "drizzle-orm/pg-core"
+import { reports } from "./reports"
+
+export const reportViews = pgTable("report_views", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  reportId: uuid("report_id")
+    .notNull()
+    .references(() => reports.id, { onDelete: "cascade" }),
+  viewedAt: timestamp("viewed_at").defaultNow().notNull()
+})
+
+export type ReportView = typeof reportViews.$inferSelect


### PR DESCRIPTION
## Summary
- record reporter page views with new `report_views` table and API endpoint
- log view when reporter checks a case
- show last reporter view in admin case info panel

## Testing
- `npm test` *(fails: No "clerkClient" export is defined; ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b09f0f00c88321847a4e0be50d923d