### PR TITLE
Refine marketing content to match app branding

### DIFF
--- a/app/(unauthenticated)/(marketing)/_components/footer.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/footer.tsx
@@ -60,7 +60,7 @@ export function Footer() {
               Signalista
             </Link>
             <p className="text-muted-foreground text-sm leading-6">
-              Leading the way in digital communication.
+              Compliant whistleblowing made simple.
             </p>
             <div className="flex space-x-6">
               {socialLinks.map(item => (

--- a/app/(unauthenticated)/(marketing)/_components/sections/cta-section.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/sections/cta-section.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { motion } from "framer-motion"
-import { ArrowRight, Github } from "lucide-react"
+import { ArrowRight } from "lucide-react"
 import Link from "next/link"
 import { SectionWrapper } from "./section-wrapper"
 
@@ -17,7 +17,7 @@ export function CTASection() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          Ready to build something amazing?
+          Ready to meet whistleblowing obligations?
         </motion.h2>
         <motion.p
           className="mx-auto mt-6 max-w-xl text-lg leading-8"
@@ -26,8 +26,8 @@ export function CTASection() {
           viewport={{ once: true }}
           transition={{ duration: 0.5, delay: 0.1 }}
         >
-          Stop wasting time on boilerplate. Clone this template and start
-          shipping your product today.
+          Launch a secure reporting channel in minutes and stay compliant
+          effortlessly.
         </motion.p>
         <motion.div
           className="mt-10 flex items-center justify-center gap-x-6"
@@ -41,12 +41,8 @@ export function CTASection() {
             className="bg-brand-primary text-brand-primary-foreground hover:bg-brand-primary-hover"
             asChild
           >
-            <Link
-              href="https://github.com/mckaywrigley/mckays-app-template"
-              target="_blank"
-            >
-              <Github className="mr-2 h-4 w-4" />
-              Clone Template
+            <Link href="/signup">
+              Get Started
               <ArrowRight className="ml-2 h-4 w-4" />
             </Link>
           </Button>
@@ -71,9 +67,9 @@ export function CTASection() {
           transition={{ duration: 0.5, delay: 0.3 }}
         >
           {[
-            { label: "Time to First Deploy", value: "< 5 min" },
-            { label: "Production Ready", value: "100%" },
-            { label: "License", value: "MIT" }
+            { label: "Anonymous reports", value: "100%" },
+            { label: "SLA tracking", value: "7d / 3m" },
+            { label: "Audit exports", value: "1‑click" }
           ].map((stat, index) => (
             <motion.div
               key={stat.label}

--- a/app/(unauthenticated)/(marketing)/_components/sections/faq-section.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/sections/faq-section.tsx
@@ -12,34 +12,29 @@ import { SectionWrapper } from "./section-wrapper"
 
 const faqs = [
   {
-    question: "What's included in the template?",
+    question: "Is reporting anonymous by default?",
     answer:
-      "Everything you need to build a production app: Next.js 15 with App Router, TypeScript, Tailwind CSS v4, shadcn/ui components, Clerk authentication, Stripe payments, PostgreSQL with Drizzle ORM, and PostHog analytics. All pre-configured and ready to use."
+      "Yes. Reporters can submit without logging in and access replies with a receipt and passphrase."
   },
   {
-    question: "How do I get started?",
+    question: "Does Sygnalista meet EU and Polish regulations?",
     answer:
-      "Simply clone the repository from GitHub, copy the .env.example to .env.local, add your API keys, run npm install, and you're ready to go. The whole process takes less than 5 minutes."
+      "The platform follows EU Directive 2019/1937 and the Polish Whistleblower Act—deadlines, encryption and audit trail included."
   },
   {
-    question: "Is this really free?",
+    question: "Can we customize categories and retention?",
     answer:
-      "Yes! This template is 100% free and open source under the MIT license. You can use it for personal projects, commercial applications, or anything else. No hidden costs or premium features."
+      "Admins can configure reporting categories, data retention and whether anonymous reports are allowed."
   },
   {
-    question: "Can I customize everything?",
+    question: "How are deadlines tracked?",
     answer:
-      "Absolutely! You have full access to all the source code. Modify the components, change the styling, add or remove features - it's your codebase now. The template is designed to be a starting point that you can build upon."
+      "Each case tracks the 7‑day acknowledgement and 3‑month feedback timers with automatic reminders."
   },
   {
-    question: "What about deployment?",
+    question: "How do we export data for auditors?",
     answer:
-      "The template works with any hosting provider that supports Next.js. Deploy to Vercel, Netlify, Railway, or any other platform. Database can be hosted on Supabase, Neon, or any PostgreSQL provider."
-  },
-  {
-    question: "How do I get help if I'm stuck?",
-    answer:
-      "Open an issue on GitHub for bugs or feature requests. For general questions, the community is active in discussions. If you need dedicated support, consider becoming a sponsor or reaching out for custom development."
+      "Generate a tamper‑evident register or case archive anytime. Monthly snapshots are stored automatically."
   }
 ]
 
@@ -74,8 +69,8 @@ export function FAQSection() {
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            Everything you need to know about the template. Can't find what
-            you're looking for? Open an issue on GitHub.
+            Everything you need to know about Sygnalista. Can't find what
+            you're looking for? Contact us.
           </motion.p>
           <dl className="mt-10 space-y-6">
             {faqs.map((faq, index) => (

--- a/app/(unauthenticated)/(marketing)/_components/sections/social-proof-section.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/sections/social-proof-section.tsx
@@ -6,24 +6,24 @@ import { SectionWrapper } from "./section-wrapper"
 
 const testimonials = [
   {
-    name: "Alex Chen",
-    role: "Indie Hacker",
+    name: "Katarzyna Nowak",
+    role: "HR Manager",
     content:
-      "This template saved me weeks of setup time. I went from idea to deployed MVP in just 2 days. The authentication and payment integration alone would have taken me a week to configure properly.",
+      "Sygnalista gave our employees a safe place to speak up. We uncovered issues early and built more trust in the process.",
     rating: 5
   },
   {
-    name: "Sarah Williams",
-    role: "Startup Founder",
+    name: "Piotr Zieliński",
+    role: "Compliance Officer",
     content:
-      "As a non-technical founder, this template was a godsend. Clean code, great documentation, and everything just works out of the box. My developer was impressed with the code quality.",
+      "The automatic SLA reminders keep our team on track and auditors love the register exports.",
     rating: 5
   },
   {
-    name: "Mike Johnson",
-    role: "Full Stack Developer",
+    name: "Anna Kowalska",
+    role: "Legal Counsel",
     content:
-      "I've tried many boilerplates, but this one hits different. Modern stack, best practices, and actually production-ready. It's now my go-to starting point for all client projects.",
+      "Monthly snapshots and the tamper‑evident log make proving diligence effortless during reviews.",
     rating: 5
   }
 ]
@@ -49,7 +49,7 @@ export function SocialProofSection() {
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            Loved by developers worldwide
+            Trusted by compliance teams
           </motion.p>
         </div>
         <div className="mx-auto mt-16 flow-root max-w-2xl sm:mt-20 lg:mx-0 lg:max-w-none">

--- a/app/(unauthenticated)/(marketing)/_components/sections/video-section.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/sections/video-section.tsx
@@ -28,7 +28,7 @@ export function VideoSection() {
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            Watch how quickly you can go from clone to deployed app
+            See a report move from submission to resolution
           </motion.p>
         </div>
 
@@ -57,16 +57,14 @@ export function VideoSection() {
                 transition={{ duration: 0.3 }}
               >
                 <pre className="overflow-hidden">
-                  <code>{`$ git clone github.com/mckaywrigley/template
-$ cd template
-$ npm install
-$ cp .env.example .env.local
-$ npm run dev
-
-✓ Ready in 3s
-○ Compiling / ...
-✓ Compiled successfully
-✓ Ready at http://localhost:3000`}</code>
+                  <code>{`$ report submit
+✓ encrypted & logged
+$ team acknowledge
+✓ within 7 days
+$ team feedback
+✓ within 3 months
+$ export audit
+✓ ready for inspectors`}</code>
                 </pre>
               </motion.div>
             </div>
@@ -92,9 +90,9 @@ $ npm run dev
             <div className="from-foreground absolute right-0 bottom-0 left-0 bg-gradient-to-t to-transparent p-6">
               <div className="text-background flex items-center justify-between">
                 <div>
-                  <h3 className="text-lg font-semibold">Quick Start Demo</h3>
+                  <h3 className="text-lg font-semibold">Case Lifecycle Demo</h3>
                   <p className="text-background/80 mt-1 text-sm">
-                    From clone to deploy in minutes
+                    From report to resolution
                   </p>
                 </div>
                 <div className="flex gap-4 text-sm">
@@ -120,14 +118,14 @@ $ npm run dev
             transition={{ duration: 0.5, delay: 0.4 }}
           >
             {[
-              "TypeScript",
-              "Next.js 15",
-              "Tailwind CSS",
-              "Clerk Auth",
-              "Stripe"
-            ].map((tech, index) => (
+              "Anonymous intake",
+              "End-to-end encryption",
+              "SLA reminders",
+              "Register & audit log",
+              "1-click exports"
+            ].map((feature, index) => (
               <motion.span
-                key={tech}
+                key={feature}
                 className="bg-muted text-muted-foreground inline-flex items-center rounded-full px-4 py-2 text-sm font-medium"
                 initial={{ opacity: 0, scale: 0.8 }}
                 whileInView={{ opacity: 1, scale: 1 }}
@@ -139,7 +137,7 @@ $ npm run dev
                   stiffness: 200
                 }}
               >
-                {tech}
+                {feature}
               </motion.span>
             ))}
           </motion.div>

--- a/app/(unauthenticated)/(marketing)/_components/sticky-cta.tsx
+++ b/app/(unauthenticated)/(marketing)/_components/sticky-cta.tsx
@@ -23,19 +23,15 @@ export function StickyCTA() {
             <div className="flex items-center justify-between gap-3">
               <div className="flex-1">
                 <p className="text-muted-foreground text-xs font-medium">
-                  Love this template?
+                  Need a secure channel?
                 </p>
                 <p className="text-foreground text-sm font-semibold">
-                  Star us on GitHub!
+                  Try Sygnalista for free
                 </p>
               </div>
               <Button size="sm" asChild className="group">
-                <Link
-                  href="https://github.com/mckaywrigley/mckays-app-template"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Start Building
+                <Link href="/signup">
+                  Get Started
                   <ArrowRight className="ml-1 h-3 w-3 transition-transform group-hover:translate-x-1" />
                 </Link>
               </Button>
@@ -88,24 +84,20 @@ export function StickyCTA() {
             <div className="space-y-4">
               <div>
                 <p className="text-muted-foreground text-sm font-medium">
-                  Love this template?
+                  Need a secure channel?
                 </p>
                 <p className="text-foreground text-lg font-bold">
-                  Star us on GitHub!
+                  Try Sygnalista for free
                 </p>
               </div>
               <Button asChild className="group w-full">
-                <Link
-                  href="https://github.com/mckaywrigley/mckays-app-template"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Start Building
+                <Link href="/signup">
+                  Get Started
                   <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                 </Link>
               </Button>
               <p className="text-muted-foreground text-center text-xs">
-                The #1 Full Stack App Template
+                EU Directive compliant from day one
               </p>
             </div>
           </motion.div>


### PR DESCRIPTION
## Summary
- Replace boilerplate CTA with signup-driven copy and product stats
- Add product-focused testimonials, FAQ, video snippet and sticky CTA
- Adjust footer tagline to highlight whistleblowing compliance

## Testing
- `npm test` *(fails: connect ENETUNREACH & missing mock)*
- `npm run lint` *(fails: multiple ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b6e719848321bb348fb43f4766d0